### PR TITLE
Fixed the cabal installation

### DIFF
--- a/Obsidian.cabal
+++ b/Obsidian.cabal
@@ -36,7 +36,7 @@ Library
                , mtl >= 2.0 
                , value-supply >= 0.6
                , containers >= 0.4.2.1
-	       , text >= 0.11.3.1
+        , text >= 0.11.3.1
              
   exposed-modules: Obsidian
                  
@@ -66,7 +66,7 @@ Library
                ,  Obsidian.CodeGen.Program
                ,  Obsidian.CodeGen.SPMDC
 
- 	       
+        
   GHC-Options: 
 -- -O2 
 

--- a/Obsidian/Program.hs
+++ b/Obsidian/Program.hs
@@ -7,7 +7,7 @@
 
 -}
 
-{-# LANGUAGE GADTs, TypeFamilies  #-}
+{-# LANGUAGE GADTs, TypeFamilies, EmptyDataDecls #-}
              
 
 


### PR DESCRIPTION
Two tab characters were removed from the cabal file and an extra pragma
was added to Program, to make it compile again.
